### PR TITLE
add support for maxWarnings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ grunt.loadNpmTasks("gruntify-eslint");
 grunt.registerTask("default", ["eslint"]);
 ```
 
-  
+
 ### [Options](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)
 
 #### configFile
@@ -118,6 +118,14 @@ Type: `Boolean`
 
 Whether the grunt task would fail on error or will it always pass irrespective of the results.
 i.e. to supress the failure.
+This option is not passed to the eslint api.
+
+#### maxWarnings
+
+Type: `Number`
+Default: `-1`
+
+Specifies a warning threshold, which will cause the task to fail if there are too many warning-level rule violations.
 This option is not passed to the eslint api.
 
 #### callback

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -10,6 +10,7 @@ module.exports = function(grunt){
         var options = this.options({
             "silent": false,
             "quiet": false,
+            "maxWarnings": -1,
             "format": "stylish",
             "callback": "false"
         });
@@ -48,6 +49,9 @@ module.exports = function(grunt){
 
         if(options.silent){
             return true;
+        }
+        else if(options.maxWarnings > -1 && response.warningCount > options.maxWarnings){
+            return false;
         }
         else{
             return response.errorCount === 0;


### PR DESCRIPTION
This simply adds support for the [--max-warnings](http://eslint.org/docs/user-guide/command-line-interface#max-warnings) functionality of the eslint cli.