### PR TITLE
Add ability for callback to modify results & prevent termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ Type: `Function`
 You can specify a call back function which would be called when eslint is done processing the files. The first argument passed in would be the results object.
 This option is not passed to the eslint api.
 
+#### terminateOnCallback
+
+Type: `Boolean`
+Default: `true`
+
+When specifying a callback gruntify-eslint will by default not output results, but instead return the return of the callback. 
+You may set `terminateOnCallback` to `false` in order to allow usual report output as long as your callback returns `undefined` or `results`.
+If you wish to modify results, have `callback` return modified `results`.
+This option is not passed to the eslint api.
+
 #### outputFile
 
 Type: `path::String`

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -12,7 +12,8 @@ module.exports = function(grunt){
             "quiet": false,
             "maxWarnings": -1,
             "format": "stylish",
-            "callback": "false"
+            "callback": "false",
+            "terminateOnCallback": "true"
         });
 
         if(this.filesSrc.length === 0){
@@ -29,7 +30,10 @@ module.exports = function(grunt){
         }
 
         if(options.callback && options.callback.constructor === Function){
-            return options.callback(response);
+            if(options.terminateOnCallback) {
+                return options.callback(response);
+            }
+            response = options.callback(response) || response;
         }
 
         formatter = eslint.getFormatter(options.format);


### PR DESCRIPTION
This commit adds the ability for a report to still be printed
even if a callback is specified. The callback also has the
option to return modified results which will be used for the
report. Backwards compatibility is maintained so anyone
upgrading should not have any issues.