### PR TITLE
update to ESLint 8 (breaking changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "email": "gyandeeps@gmail.com"
   },
   "dependencies": {
-    "eslint": "^7.0.0"
+    "eslint": "^8.0.0-beta.2"
   },
   "devDependencies": {
     "shelljs": "~0.3.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "email": "gyandeeps@gmail.com"
   },
   "dependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "^7.0.0"
   },
   "devDependencies": {
     "shelljs": "~0.3.0"


### PR DESCRIPTION
This updates to ESLint 8, which has breaking changes, and which also means gruntify-eslint will have breaking changes (the callback option now accepts an array of `LintResult`).

- [ ] Update README:
  - [ ] There is no configFile option for `new ESLint(options)`, etc.
  - [ ] Callback first argument passed in is the results array